### PR TITLE
Don't get the body for HEAD requests

### DIFF
--- a/proxy.php
+++ b/proxy.php
@@ -97,6 +97,8 @@ class Proxy {
                 $this->set_post($post);
             }
             
+        } elseif ($_SERVER["REQUEST_METHOD"] == "HEAD") {
+          curl_setopt($this->ch, CURLOPT_NOBODY, true);
         }
         
         // execute


### PR DESCRIPTION
There is no need for the body in case of HEAD request ad also, curl will change the request method to the server to HEAD.
