### PR TITLE
Added missing parent folder for adapters.

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -69,7 +69,7 @@ class Factory {
      */
     protected static function createAdapter($adapter)
     {
-        $class = '\\Proxy\\Adapter\\' . ucfirst($adapter) . 'Adapter';
+        $class = '\\Proxy\\Adapter\\' . ucfirst($adapter) . '\\' . ucfirst($adapter) . 'Adapter';
 
         if (class_exists($class))
         {


### PR DESCRIPTION
Loading adapters was failing because the adapter files were being loaded from `Proxy\Adapter` instead of `Proxy\Adapter\<adapter_type>`.
