### PR TITLE
Proxy does not respect port 80 or 443 on target

### DIFF
--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -76,9 +76,20 @@ class Proxy {
             ->withHost($target->getHost());
 
         // Check for custom port.
-        if ($port = $target->getPort()) {
-            $uri = $uri->withPort($port);
+        $port = $target->getPort();
+
+        if ($port === null) {
+            switch ($target->getScheme()) {
+                case 'http':
+                    $port = 80;
+                    break;
+                case 'https':
+                    $port = 443;
+                    break;
+            }
         }
+
+        $uri = $uri->withPort($port);
 
         // Check for subdirectory.
         if ($path = $target->getPath()) {


### PR DESCRIPTION
This is needed for when you have a server not running on port 80 or 443 (such as the php built-in webserver `php -S localhost:8080`). And you want to forward the request to a server with port 80 or 443.
