### PR TITLE
Package satooshi/php-coveralls is abandoned, you should avoid using i…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0|^6.0|^7.0",
-        "satooshi/php-coveralls": "^2.0",
+        "php-coveralls/php-coveralls": "^2.0",
         "mockery/mockery": "^1.1"
     },
     "autoload": {


### PR DESCRIPTION
…t. Use php-coveralls/php-coveralls instead.

as can be seen in the travis-ci builds logs