### PR TITLE
Allow zendframework/zend-diactoros 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^5.6 || ^7.0",
         "psr/http-message": "^1.0",
         "guzzlehttp/guzzle": "^6.0",
-        "zendframework/zend-diactoros": "^1.0",
+        "zendframework/zend-diactoros": "^1.0 || ^2.0",
         "relay/relay": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Some recent modules require later versions of zend-diactoros which create composer conflicts.