### PR TITLE
setting query parameters if exists in target URL

### DIFF
--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -71,7 +71,8 @@ class Proxy
 
         // Check for subdirectory.
         if ($path = $target->getPath()) {
-            $uri = $uri->withPath(rtrim($path, '/') . '/' . ltrim($uri->getPath(), '/'));
+            $uriPath = ltrim($uri->getPath(), '/');
+            $uri = $uri->withPath(rtrim($path, '/') . (!empty($uriPath) ? ('/' . ltrim($uri->getPath(), '/')) : ''));
         }
 
         //check for query parameters.

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -74,6 +74,11 @@ class Proxy
             $uri = $uri->withPath(rtrim($path, '/') . '/' . ltrim($uri->getPath(), '/'));
         }
 
+        //check for query parameters.
+        if ($query = $target->getQuery()) {
+            $uri = $uri->withQuery($query);
+        }
+
         $request = $this->request->withUri($uri);
 
         $stack = $this->filters;


### PR DESCRIPTION
The query parameters were not considered when building uri in the proxy.