### PR TITLE
Update for newer PHP and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 php:
   - 7.3
   - 7.4
-  - nightly
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ language: php
 php:
   - 7.3
   - 7.4
-  - 8.0
+  - nightly
 
 sudo: false
 
-dist: focal
+dist: bionic
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
   - 7.3
+  - 7.4
+  - 8.0
 
 sudo: false
 
-dist: trusty
+dist: focal
 
 before_script:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 This is a HTTP/HTTPS proxy script that forwards requests to a different server and returns the response. The Proxy class uses PSR7 request/response objects as input/output, and uses Guzzle to do the actual HTTP request.
 
+x
 ## Installation
 
 Install using composer:

--- a/README.md
+++ b/README.md
@@ -35,11 +35,16 @@ $proxy = new Proxy(new GuzzleAdapter($guzzle));
 // Add a response filter that removes the encoding headers.
 $proxy->filter(new RemoveEncodingFilter());
 
-// Forward the request and get the response.
-$response = $proxy->forward($request)->to('http://example.com');
+try {
+    // Forward the request and get the response.
+    $response = $proxy->forward($request)->to('http://example.com');
 
-// Output response to the browser.
-(new Laminas\HttpHandlerRunner\Emitter\SapiEmitter)->emit($response);
+    // Output response to the browser.
+    (new Laminas\HttpHandlerRunner\Emitter\SapiEmitter)->emit($response);
+} catch(\GuzzleHttp\Exception\BadResponseException $e) {
+    // Correct way to handle bad responses
+    (new Laminas\HttpHandlerRunner\Emitter\SapiEmitter)->emit($e->getResponse());
+}
 ```
 
 ## Filters

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This is a HTTP/HTTPS proxy script that forwards requests to a different server and returns the response. The Proxy class uses PSR7 request/response objects as input/output, and uses Guzzle to do the actual HTTP request.
 
-x
+
 ## Installation
 
 Install using composer:

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
         }
     ],
     "require": {
-        "php": "^7.0||^8.0",
+        "php": "^7.3",
         "psr/http-message": "^1.0",
-        "guzzlehttp/guzzle": "^6.0||^7.1",
-        "laminas/laminas-diactoros": "^2.0",
+        "guzzlehttp/guzzle": "^7.1",
+        "laminas/laminas-diactoros": "^2.4",
         "relay/relay": "^1.0",
-        "laminas/laminas-httphandlerrunner": "^1.1"
+        "laminas/laminas-httphandlerrunner": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0|^6.0|^7.0",
+        "phpunit/phpunit": "^9.0",
         "php-coveralls/php-coveralls": "^2.0",
         "mockery/mockery": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,9 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.0||^8.0",
         "psr/http-message": "^1.0",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^6.0||^7.1",
         "laminas/laminas-diactoros": "^2.0",
         "relay/relay": "^1.0",
         "laminas/laminas-httphandlerrunner": "^1.1"

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,10 @@
         "laminas/laminas-httphandlerrunner": "^1.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0",
-        "php-coveralls/php-coveralls": "^2.0",
-        "mockery/mockery": "^1.1"
+        "roave/security-advisories": "dev-latest",
+        "phpunit/phpunit": "^9.5",
+        "php-coveralls/php-coveralls": "^2.4",
+        "mockery/mockery": "^1.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "psr/http-message": "^1.0",
         "guzzlehttp/guzzle": "^7.1",
-        "laminas/laminas-diactoros": "^2.4",
+        "laminas/laminas-diactoros": "^2.5",
         "relay/relay": "^1.0",
         "laminas/laminas-httphandlerrunner": "^1.2"
     },

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,22 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="true"
->
-    <testsuites>
-        <testsuite name="PHPProxy Test Suite">
-            <directory>tests/Proxy/</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  backupGlobals="false"
+  backupStaticAttributes="false"
+  bootstrap="vendor/autoload.php"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  processIsolation="false"
+  stopOnFailure="true"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHPProxy Test Suite">
+      <directory>tests/Proxy/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Proxy.php
+++ b/src/Proxy.php
@@ -2,6 +2,7 @@
 
 namespace Proxy;
 
+use GuzzleHttp\Exception\ClientException;
 use Proxy\Adapter\AdapterInterface;
 use Proxy\Exception\UnexpectedValueException;
 use Psr\Http\Message\RequestInterface;
@@ -79,7 +80,11 @@ class Proxy
         $stack = $this->filters;
 
         $stack[] = function (RequestInterface $request, ResponseInterface $response, callable $next) {
-            $response = $this->adapter->send($request);
+            try {
+                $response = $this->adapter->send($request);
+            } catch (ClientException $ex) {
+                $response = $ex->getResponse();
+            }
 
             return $next($request, $response);
         };

--- a/tests/Proxy/Adapter/Dummy/DummyAdapterTest.php
+++ b/tests/Proxy/Adapter/Dummy/DummyAdapterTest.php
@@ -13,7 +13,7 @@ class DummyAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->adapter = new DummyAdapter();
     }

--- a/tests/Proxy/Adapter/Guzzle/GuzzleAdapterTest.php
+++ b/tests/Proxy/Adapter/Guzzle/GuzzleAdapterTest.php
@@ -32,7 +32,7 @@ class GuzzleAdapterTest extends TestCase
      */
     private $body = 'Totally awesome response body';
 
-    public function setUp()
+    public function setUp(): void
     {
         $mock = new MockHandler([
             $this->createResponse(),

--- a/tests/Proxy/Filter/RemoveEncodingFilterTest.php
+++ b/tests/Proxy/Filter/RemoveEncodingFilterTest.php
@@ -13,7 +13,7 @@ class RemoveEncodingFilterTest extends TestCase
      */
     private $filter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->filter = new RemoveEncodingFilter();
     }

--- a/tests/Proxy/Filter/RemoveLocationFilterTest.php
+++ b/tests/Proxy/Filter/RemoveLocationFilterTest.php
@@ -13,7 +13,7 @@ class RemoveLocationFilterTest extends TestCase
      */
     private $filter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->filter = new RemoveLocationFilter();
     }

--- a/tests/Proxy/Filter/RewriteLocationFilterTest.php
+++ b/tests/Proxy/Filter/RewriteLocationFilterTest.php
@@ -11,7 +11,7 @@ class RewriteLocationFilterTest extends TestCase
      */
     private $filter;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->filter = new RewriteLocationFilter();
     }

--- a/tests/Proxy/ProxyTest.php
+++ b/tests/Proxy/ProxyTest.php
@@ -17,17 +17,17 @@ class ProxyTest extends TestCase
      */
     private $proxy;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->proxy = new Proxy(new DummyAdapter());
     }
 
     /**
      * @test
-     * @expectedException UnexpectedValueException
      */
     public function to_throws_exception_if_no_request_is_given()
     {
+        $this->expectException('UnexpectedValueException');
         $this->proxy->to('http://www.example.com');
     }
 


### PR DESCRIPTION
This PR makes the test suite run (successfully) on PHP 7.3. and 7.4, raises the minimum to PHP 7.3 (the oldest currently supported release), and updates various dependencies for more recent versions, in particular PHPUnit 9 and Guzzle 7.

I tried it on PHP 8.0 but it breaks because there is no compatible version of laminas/laminas-diactoros on 8.0 yet so I left that out of this PR, but at least you know where the problems lie.

If this is merged and tagged, I recommend bumping the major version since these updates amount to a BC break.