### PR TITLE
All composer requires up-to-date, includes and closes PR #90 and resolves #87

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Tests with PHPUnit
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate --strict
+
+    - name: Cache Composer packages
+      id: composer-cache
+      uses: actions/cache@v2
+      with:
+        path: vendor
+        key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-php-
+    - name: Install dependencies
+      run: composer install --prefer-dist --no-progress
+
+    - name: Run test suite
+      run: composer run-script test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
   - 7.3
+  - 7.4
+  - 8.0
 
 sudo: false
 
-dist: trusty
+dist: bionic
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -38,5 +38,8 @@
         "psr-4": {
             "Proxy\\": "tests"
         }
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,9 @@
 {
     "name": "jenssegers/proxy",
     "description": "Proxy library that forwards requests to the desired url and returns the response.",
-    "keywords": ["proxy"],
+    "keywords": [
+        "proxy"
+    ],
     "homepage": "https://github.com/jenssegers/php-proxy",
     "license": "MIT",
     "authors": [
@@ -16,17 +18,16 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
-        "psr/http-message": "^1.0",
-        "guzzlehttp/guzzle": "^6.0",
+        "php": "^7.3|^8.0",
+        "guzzlehttp/guzzle": "^7.0.1",
         "laminas/laminas-diactoros": "^2.0",
-        "relay/relay": "^1.0",
+        "relay/relay": "~2.0",
         "laminas/laminas-httphandlerrunner": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0|^6.0|^7.0",
+        "phpunit/phpunit": "^9.3",
         "php-coveralls/php-coveralls": "^2.0",
-        "mockery/mockery": "^1.1"
+        "mockery/mockery": "^1.4.2"
     },
     "autoload": {
         "psr-4": {

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -14,5 +14,5 @@ interface FilterInterface
      * @param callable $next
      * @return ResponseInterface
      */
-    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next);
+    public function __invoke(RequestInterface $request, callable $next): ResponseInterface;
 }

--- a/src/Filter/RemoveEncodingFilter.php
+++ b/src/Filter/RemoveEncodingFilter.php
@@ -13,9 +13,9 @@ class RemoveEncodingFilter implements FilterInterface
     /**
      * @inheritdoc
      */
-    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next)
+    public function __invoke(RequestInterface $request, callable $next): ResponseInterface
     {
-        $response = $next($request, $response);
+        $response = $next($request);
 
         return $response
             ->withoutHeader(self::TRANSFER_ENCODING)

--- a/src/Filter/RemoveLocationFilter.php
+++ b/src/Filter/RemoveLocationFilter.php
@@ -12,9 +12,9 @@ class RemoveLocationFilter implements FilterInterface
     /**
      * @inheritdoc
      */
-    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next)
+    public function __invoke(RequestInterface $request, callable $next): ResponseInterface
     {
-        $response = $next($request, $response);
+        $response = $next($request);
 
         if ($response->hasHeader(self::LOCATION)) {
             $response = $response

--- a/src/Filter/RewriteLocationFilter.php
+++ b/src/Filter/RewriteLocationFilter.php
@@ -12,9 +12,9 @@ class RewriteLocationFilter implements FilterInterface
     /**
      * @inheritdoc
      */
-    public function __invoke(RequestInterface $request, ResponseInterface $response, callable $next)
+    public function __invoke(RequestInterface $request, callable $next): ResponseInterface
     {
-        $response = $next($request, $response);
+        $response = $next($request);
 
         if ($response->hasHeader(self::LOCATION)) {
             $location = $response->getHeader(self::LOCATION)[0];

--- a/tests/Proxy/Adapter/Dummy/DummyAdapterTest.php
+++ b/tests/Proxy/Adapter/Dummy/DummyAdapterTest.php
@@ -13,7 +13,7 @@ class DummyAdapterTest extends TestCase
      */
     private $adapter;
 
-    public function setUp()
+    public function setUp(): Void
     {
         $this->adapter = new DummyAdapter();
     }

--- a/tests/Proxy/Adapter/Guzzle/GuzzleAdapterTest.php
+++ b/tests/Proxy/Adapter/Guzzle/GuzzleAdapterTest.php
@@ -32,7 +32,7 @@ class GuzzleAdapterTest extends TestCase
      */
     private $body = 'Totally awesome response body';
 
-    public function setUp()
+    public function setUp(): Void
     {
         $mock = new MockHandler([
             $this->createResponse(),

--- a/tests/Proxy/Filter/RemoveEncodingFilterTest.php
+++ b/tests/Proxy/Filter/RemoveEncodingFilterTest.php
@@ -13,7 +13,7 @@ class RemoveEncodingFilterTest extends TestCase
      */
     private $filter;
 
-    public function setUp()
+    public function setUp(): Void
     {
         $this->filter = new RemoveEncodingFilter();
     }
@@ -29,7 +29,7 @@ class RemoveEncodingFilterTest extends TestCase
             return $response;
         };
 
-        $response = call_user_func($this->filter, $request, $response, $next);
+        $response = call_user_func($this->filter, $request, $next);
 
         $this->assertFalse($response->hasHeader(RemoveEncodingFilter::TRANSFER_ENCODING));
     }
@@ -41,11 +41,11 @@ class RemoveEncodingFilterTest extends TestCase
     {
         $request = new Request();
         $response = new Response('php://memory', 200, [RemoveEncodingFilter::TRANSFER_ENCODING => 'foo']);
-        $next = function ($request, $response) {
+        $next = function () use ($response) {
             return $response;
         };
 
-        $response = call_user_func($this->filter, $request, $response, $next);
+        $response = call_user_func($this->filter, $request, $next);
 
         $this->assertFalse($response->hasHeader(RemoveEncodingFilter::CONTENT_ENCODING));
     }

--- a/tests/Proxy/Filter/RemoveLocationFilterTest.php
+++ b/tests/Proxy/Filter/RemoveLocationFilterTest.php
@@ -13,7 +13,7 @@ class RemoveLocationFilterTest extends TestCase
      */
     private $filter;
 
-    public function setUp()
+    public function setUp(): Void
     {
         $this->filter = new RemoveLocationFilter();
     }
@@ -29,7 +29,7 @@ class RemoveLocationFilterTest extends TestCase
             return $response;
         };
 
-        $response = call_user_func($this->filter, $request, $response, $next);
+        $response = call_user_func($this->filter, $request, $next);
 
         $this->assertFalse($response->hasHeader(RemoveLocationFilter::LOCATION));
     }
@@ -45,7 +45,7 @@ class RemoveLocationFilterTest extends TestCase
             return $response;
         };
 
-        $response = call_user_func($this->filter, $request, $response, $next);
+        $response = call_user_func($this->filter, $request, $next);
 
         $this->assertEquals('http://www.example.com', $response->getHeader('X-Proxy-Location')[0]);
     }

--- a/tests/Proxy/Filter/RewriteLocationFilterTest.php
+++ b/tests/Proxy/Filter/RewriteLocationFilterTest.php
@@ -1,4 +1,6 @@
-<?php namespace Proxy\Filter;
+<?php
+
+namespace Proxy\Filter;
 
 use PHPUnit\Framework\TestCase;
 use Laminas\Diactoros\Request;
@@ -11,7 +13,7 @@ class RewriteLocationFilterTest extends TestCase
      */
     private $filter;
 
-    public function setUp()
+    public function setUp(): Void
     {
         $this->filter = new RewriteLocationFilter();
     }
@@ -30,7 +32,7 @@ class RewriteLocationFilterTest extends TestCase
             return $response;
         };
 
-        $response = call_user_func($this->filter, $request, $response, $next);
+        $response = call_user_func($this->filter, $request, $next);
 
         $this->assertTrue($response->hasHeader('X-Proxy-Location'));
         $this->assertTrue($response->hasHeader(RewriteLocationFilter::LOCATION));


### PR DESCRIPTION
All composer requires up-to-date
Includes and closes PR #90
resolves #87

These updates should allow someone to simply composer require the package and use the example code in the current README with success.

Tested on 
PHP 
- 7.4.3
- 8.0.8

Tested on Laravel Framework 
- Laravel Framework 8.58.0
- Laravel Lumen (8.2.4) (Laravel Components ^8.0)

